### PR TITLE
chore: use ConnectData.cochainComplex to make Tate complex

### DIFF
--- a/ClassFieldTheory/GroupCohomology/_1_TateCohomology_def.lean
+++ b/ClassFieldTheory/GroupCohomology/_1_TateCohomology_def.lean
@@ -46,87 +46,14 @@ lemma TateNorm_comp_d (M : Rep R G) : TateNorm M ≫ (inhomogeneousCochains M).d
 lemma d_comp_TateNorm (M : Rep R G) : (inhomogeneousChains M).d 1 0 ≫ TateNorm M  = 0 :=
   sorry
 
-def TateComplex (M : Rep R G) : CochainComplex (ModuleCat R) ℤ where
-  X
-  | Int.ofNat n => (inhomogeneousCochains M).X n
-  | Int.negSucc n => (inhomogeneousChains M).X n
-  d
-  | Int.ofNat i, Int.ofNat j            => (inhomogeneousCochains M).d i j
-  | Int.ofNat _, Int.negSucc _          => 0
-  | -1,0                                => TateNorm M
-  | -1, Int.ofNat (j + 1)               => 0
-  | -1, Int.negSucc _                   => 0
-  | Int.negSucc (i + 1), Int.ofNat j    => 0
-  | Int.negSucc (i + 1), Int.negSucc j  => (inhomogeneousChains M).d (i + 1) j
-  shape
-  | Int.ofNat i, Int.ofNat j => by
-      convert (inhomogeneousCochains M).shape i j
-      simp only [Int.ofNat_eq_coe, ComplexShape.up_Rel]
-      norm_cast
-  | Int.ofNat _, Int.negSucc _ => by tauto
-  | Int.negSucc 0, 0 => by intro; contradiction
-  | -1, Int.ofNat (j + 1) => by tauto
-  | -1, Int.negSucc _ => by tauto
-  | Int.negSucc (i + 1), Int.ofNat j => by tauto
-  | Int.negSucc (i + 1), Int.negSucc j => by
-      convert (inhomogeneousChains M).shape (i + 1) j
-      rw [ComplexShape.up_Rel, ComplexShape.down_Rel, Int.negSucc_eq, Int.negSucc_eq,
-        Nat.cast_add, Nat.cast_one, neg_add, neg_add, neg_add, add_comm, ←add_assoc, add_left_inj,
-        add_comm, add_assoc, neg_add_cancel, add_zero, neg_eq_iff_eq_neg, neg_neg, Nat.cast_inj,
-        add_left_inj, Eq.comm]
-  d_comp_d' i j k hij hjk := by
-    cases i with
-    | ofNat i =>
-      cases j with
-      | ofNat j =>
-        cases k with
-        | ofNat k =>
-          simp only [Int.ofNat_eq_coe, ComplexShape.up_Rel] at hij hjk
-          norm_cast at hij hjk
-          apply (inhomogeneousCochains M).d_comp_d' i j k hij hjk
-        | negSucc _ =>
-          contradiction
-      | negSucc _ =>
-        contradiction
-    | negSucc i =>
-      cases i with
-      | zero =>
-        simp only [Int.reduceNegSucc, ComplexShape.up_Rel, Int.reduceNeg, neg_add_cancel] at hij hjk
-        rw [←hjk,←hij]
-        exact TateNorm_comp_d M
-      | succ i =>
-        cases i with
-        | zero =>
-          simp only [zero_add, Int.reduceNegSucc, ComplexShape.up_Rel, Int.reduceNeg,
-            Int.reduceAdd] at hij hjk
-          rw [←hjk,←hij]
-          exact d_comp_TateNorm M
-        | succ i =>
-          cases j with
-          | ofNat _ => contradiction
-          | negSucc j =>
-            cases k with
-            | ofNat k =>
-              exfalso
-              simp only [Int.negSucc_eq, neg_add_rev, Int.reduceNeg,
-                Int.ofNat_eq_coe, ComplexShape.up_Rel, neg_add_cancel_comm,
-                Nat.neg_cast_eq_cast] at hjk
-              simp only [Int.negSucc_eq, Nat.cast_add, Nat.cast_one, neg_add_rev, Int.reduceNeg,
-                hjk.1, CharP.cast_eq_zero, zero_add, ComplexShape.up_Rel, neg_add_cancel_comm,
-                add_eq_left] at hij
-              rw [←neg_add, neg_eq_zero, add_comm] at hij
-              norm_cast at hij
-            | negSucc k =>
-              simp only [Nat.cast_one, Int.negSucc_eq, Nat.cast_add, neg_add_rev, Int.reduceNeg,
-                ComplexShape.up_Rel, neg_add_cancel_comm, add_right_inj] at hij hjk
-              rw [←neg_add, neg_eq_iff_eq_neg, neg_neg] at hij hjk
-              norm_cast at hij hjk
-              subst hjk
-              simp at hij
-              subst hij
-              rw [add_comm 1 i]
-              dsimp
-              exact (inhomogeneousChains M).d_comp_d' _ _ i rfl rfl
+def TateComplex.ConnectData (M : Rep R G) :
+    CochainComplex.ConnectData (inhomogeneousChains M) (inhomogeneousCochains M) where
+  d₀ := TateNorm M
+  comp_d₀ := d_comp_TateNorm M
+  d₀_comp := TateNorm_comp_d M
+
+def TateComplex (M : Rep R G) : CochainComplex (ModuleCat R) ℤ :=
+  CochainComplex.ConnectData.cochainComplex (TateComplex.ConnectData M)
 
 lemma TateComplex_d_neg_one (M : Rep R G) : (TateComplex M).d (-1) 0 = TateNorm M := rfl
 
@@ -156,6 +83,7 @@ The next two statements say that `TateComplexFunctor` is an exact functor.
 instance TateComplexFunctor_preservesFiniteLimits :
     PreservesFiniteLimits (TateComplexFunctor (R := R) (G := G)) :=
   sorry
+
 instance TateComplexFunctor_preservesFiniteColimits :
     PreservesFiniteColimits (TateComplexFunctor (R := R) (G := G)) :=
   sorry

--- a/ClassFieldTheory/GroupCohomology/_5_DimensionShift.lean
+++ b/ClassFieldTheory/GroupCohomology/_5_DimensionShift.lean
@@ -329,13 +329,15 @@ lemma TateCohomology_ind₁' (M : Rep R G) {H : Type} [Group H] [DecidableEq H] 
   -/
   sorry
 
-instance (M : Rep R G) [DecidableEq G] (n : ℤ) : IsIso (TateCohomology.δ (up_shortExact M) n) :=
+instance instIsIso_up_shortExact (M : Rep R G) [DecidableEq G] (n : ℤ) :
+    IsIso (TateCohomology.δ (up_shortExact M) n) :=
   /-
   This follows from `TateCohomology_coind₁'`.
   -/
   sorry
 
-instance (M : Rep R G) [DecidableEq G] (n : ℤ) : IsIso (TateCohomology.δ (down_shortExact M) n) := by
+instance instIsIso_down_shortExact (M : Rep R G) [DecidableEq G] (n : ℤ) :
+    IsIso (TateCohomology.δ (down_shortExact M) n) := by
   /-
   This follows from `TateCohomology_coind₁'`.
   -/
@@ -343,6 +345,9 @@ instance (M : Rep R G) [DecidableEq G] (n : ℤ) : IsIso (TateCohomology.δ (dow
 
 def upδiso_Tate (n : ℤ) [DecidableEq G] (M : Rep R G) :
     (TateCohomology n).obj (up.obj M) ≅ (TateCohomology (n + 1)).obj M :=
+  -- typeclass inference spends a long time failing to apply `instIsIso_down_shortExact`
+  -- so let's shortcut the instance
+  have := instIsIso_up_shortExact M n
   asIso (TateCohomology.δ (up_shortExact M) n)
 
 def downδiso_Tate (n : ℤ) [DecidableEq G] (M : Rep R G) :


### PR DESCRIPTION
We should use the mathlib-sanctioned way to glue these complexes