### PR TITLE
Project 1: (representations of subsingletons have trivial (Tate) (co)homology)

### DIFF
--- a/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
+++ b/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
@@ -127,24 +127,16 @@ instance [Subsingleton G] (M : Rep R G) : M.TrivialTateCohomology := by
   match n with
   | .ofNat 0 =>
     refine IsZero.of_iso ?_ (TateCohomology_zero_iso_of_isTrivial _)
-    rw [Nat.card_unique, Nat.cast_one]
-    have : LinearMap.range (1 : M'.V →ₗ[R] M'.V) = ⊤ :=
-      LinearMap.range_eq_top_of_cancel fun _ _ a ↦ a
-    rw [this]
-    exact ModuleCat.isZero_of_subsingleton (ModuleCat.of R (M'.V ⧸ ⊤))
+    rw [Nat.card_unique, Nat.cast_one, LinearMap.range_eq_top_of_cancel (by exact fun _ _ a ↦ a)]
+    exact ModuleCat.isZero_of_subsingleton _
   | .ofNat (n + 1) =>
-    exact IsZero.of_iso (isZero_of_trivialCohomology)
-      (TateCohomology.isoGroupCohomology n M')
+    exact (isZero_of_trivialCohomology).of_iso (TateCohomology.isoGroupCohomology n M')
   | .negSucc 0 =>
     refine IsZero.of_iso ?_ (TateCohomology_neg_one_iso_of_isTrivial _)
-    rw [Nat.card_unique, Nat.cast_one]
-    have : LinearMap.ker (1 : M'.V →ₗ[R] M'.V) = ⊥ :=
-      LinearMap.ker_eq_bot_of_cancel fun _ _ a ↦ a
-    rw [this]
-    apply ModuleCat.isZero_of_subsingleton (ModuleCat.of R _)
+    rw [Nat.card_unique, Nat.cast_one, LinearMap.ker_eq_bot_of_cancel (by exact fun _ _ a ↦ a)]
+    exact ModuleCat.isZero_of_subsingleton _
   | .negSucc (n + 1) =>
     rw [show (Int.negSucc (n + 1)) = -n - 2 by grind]
-    exact IsZero.of_iso isZero_of_trivialHomology
-      (TateCohomology.isoGroupHomology n M')
+    exact isZero_of_trivialHomology.of_iso (TateCohomology.isoGroupHomology n M')
 
 end Rep

--- a/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
+++ b/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
@@ -102,41 +102,39 @@ instance TrivialTateCohomology.to_trivialHomology [Finite G] {M : Rep R G}
     exact (TrivialTateCohomology.isZero _ hφ).of_iso
       (TateCohomology.isoGroupHomology n (M ↓ φ)).symm
 
-instance [Subsingleton G] (M : Rep R G) : M.TrivialCohomology := by
-  constructor
-  intro H _ _ _ hf _
-  letI : Subsingleton H := Function.Injective.subsingleton hf
-  apply isZero_groupCohomology_succ_of_subsingleton
+instance [Subsingleton G] {M : Rep R G} :
+    M.TrivialCohomology where
+  isZero H _ _ _ hf _ := by
+    letI : Subsingleton H := Function.Injective.subsingleton hf
+    apply isZero_groupCohomology_succ_of_subsingleton
 
-instance [Subsingleton G] (M : Rep R G) : M.TrivialHomology := by
-  constructor
-  intro H _ _ _ hf _
-  letI : Subsingleton H := Function.Injective.subsingleton hf
-  apply isZero_groupHomology_succ_of_subsingleton
+instance [Subsingleton G] {M : Rep R G} :
+    M.TrivialHomology where
+  isZero H _ _ _ hf _ := by
+    letI : Subsingleton H := Function.Injective.subsingleton hf
+    apply isZero_groupHomology_succ_of_subsingleton
 
-instance [Subsingleton G] (M : Rep R G) : M.TrivialTateCohomology := by
-  constructor
-  intro H _ _ f hf n
-  let : Subsingleton H := Function.Injective.subsingleton hf
-  set M' := (Rep.res f).obj M
-  letI : M'.ρ.IsTrivial := by
-    constructor
-    intro g
-    rw [Subsingleton.eq_one g, map_one]
-    rfl
-  match n with
-  | .ofNat 0 =>
-    refine IsZero.of_iso ?_ (TateCohomology_zero_iso_of_isTrivial _)
-    rw [Nat.card_unique, Nat.cast_one, LinearMap.range_eq_top_of_cancel (by exact fun _ _ a ↦ a)]
-    exact ModuleCat.isZero_of_subsingleton _
-  | .ofNat (n + 1) =>
-    exact (isZero_of_trivialCohomology).of_iso (TateCohomology.isoGroupCohomology n M')
-  | .negSucc 0 =>
-    refine IsZero.of_iso ?_ (TateCohomology_neg_one_iso_of_isTrivial _)
-    rw [Nat.card_unique, Nat.cast_one, LinearMap.ker_eq_bot_of_cancel (by exact fun _ _ a ↦ a)]
-    exact ModuleCat.isZero_of_subsingleton _
-  | .negSucc (n + 1) =>
-    rw [show (Int.negSucc (n + 1)) = -n - 2 by grind]
-    exact isZero_of_trivialHomology.of_iso (TateCohomology.isoGroupHomology n M')
+instance [Subsingleton G] {M : Rep R G} :
+    M.TrivialTateCohomology where
+  isZero H _ _ f hf n := by
+    let : Subsingleton H := Function.Injective.subsingleton hf
+    let : ((Rep.res f).obj M).ρ.IsTrivial := {
+      out g := by
+        rw [Subsingleton.eq_one g, map_one]
+        rfl }
+    match n with
+    | .ofNat 0 =>
+      refine IsZero.of_iso ?_ (TateCohomology_zero_iso_of_isTrivial _)
+      rw [Nat.card_unique, Nat.cast_one, LinearMap.range_eq_top_of_cancel (by exact fun _ _ a ↦ a)]
+      exact ModuleCat.isZero_of_subsingleton _
+    | .ofNat (n + 1) =>
+      exact (isZero_of_trivialCohomology).of_iso (TateCohomology.isoGroupCohomology n ((Rep.res f).obj M))
+    | .negSucc 0 =>
+      refine IsZero.of_iso ?_ (TateCohomology_neg_one_iso_of_isTrivial _)
+      rw [Nat.card_unique, Nat.cast_one, LinearMap.ker_eq_bot_of_cancel (by exact fun _ _ a ↦ a)]
+      exact ModuleCat.isZero_of_subsingleton _
+    | .negSucc (n + 1) =>
+      rw [show Int.negSucc (n + 1) = -n - 2 by grind]
+      exact isZero_of_trivialHomology.of_iso (TateCohomology.isoGroupHomology n ((Rep.res f).obj M))
 
 end Rep

--- a/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
+++ b/ClassFieldTheory/GroupCohomology/_5_TrivialCohomology.lean
@@ -57,21 +57,15 @@ lemma Rep.trivialHomology_of_iso {M N : Rep R G} (f : M ≅ N) [N.TrivialHomolog
 
 lemma groupCohomology.isZero_of_trivialCohomology [DecidableEq G] {M : Rep R G}
     [M.TrivialCohomology] (n : ℕ) :
-    IsZero (groupCohomology M (n + 1)) := by
-  apply IsZero.of_iso
-  apply Rep.TrivialCohomology.zero (M := M) (φ := (MonoidHom.id G))
-  exact fun ⦃a₁ a₂⦄ a ↦ a
-  exact n
-  apply Iso.refl
+    IsZero (groupCohomology M (n + 1)) :=
+  IsZero.of_iso
+    (Rep.TrivialCohomology.zero (φ := (MonoidHom.id G)) (fun _ _ a ↦ a)) (Iso.refl _)
 
 lemma groupHomology.isZero_of_trivialHomology [DecidableEq G] {M : Rep R G}
     [M.TrivialHomology] (n : ℕ) :
-    IsZero (groupHomology M (n + 1)) := by
-  apply IsZero.of_iso
-  apply Rep.TrivialHomology.zero (M := M) (φ := (MonoidHom.id G))
-  exact fun ⦃a₁ a₂⦄ a ↦ a
-  exact n
-  apply Iso.refl
+    IsZero (groupHomology M (n + 1)) :=
+  IsZero.of_iso
+    (Rep.TrivialHomology.zero (φ := (MonoidHom.id G)) (fun _ _ a ↦ a)) (Iso.refl _)
 
 class Rep.TrivialTateCohomology [Finite G] (M : Rep R G) : Prop where
   zero {H : Type} [Group H] [DecidableEq H] {φ : H →* G} (inj : Function.Injective φ) {n : ℤ} :


### PR DESCRIPTION
We show that representations of subsingleton groups have trivial (Tate) (co)homology:

```
variable {R G : Type} [CommRing R] [Group G] [Subsingleton G] (M : Rep R G)

instance : M.TrivialCohomology := sorry

instance : M.TrivialHomology := sorry

instance : M.TrivialTateCohomology := sorry
```
