### PR TITLE
 feat: versions of ind₁/coind₁ defined as finsupp/pi

### DIFF
--- a/ClassFieldTheory/GroupCohomology/_7_coind1_and_ind1.lean
+++ b/ClassFieldTheory/GroupCohomology/_7_coind1_and_ind1.lean
@@ -458,13 +458,13 @@ variable (G) in
 
 variable (G) in
 /-- A version of `coind₁` that's actually defined as `G → A` with some action. -/
-@[simps! V] def coind₁AsPi : Rep R G  :=   coind₁'.obj <| (trivialFunctor R G).obj A
+@[simps! V] def coind₁AsPi : Rep R G := coind₁'.obj <| (trivialFunctor R G).obj A
 
 @[simp]
 lemma ind₁AsFinsupp_ρ (g : G) : (ind₁AsFinsupp G A).ρ g = lmapDomain _ _ (fun x ↦ x * g⁻¹) := by
   simp [ind₁AsFinsupp, trivialFunctor]
 
--- TODO: Replace with `coind₁AsPi_ρ`. Currently can't be proved for obscure reasons.
+-- TODO: Replace with `coind₁AsPi_ρ`. Currently can't be proved first for obscure reasons.
 @[simp]
 lemma coind₁AsPi_ρ_apply (g : G) (f : G → A) (x : G) : (coind₁AsPi G A).ρ g f x = f (x * g) := by
   simp [coind₁AsPi, coind₁', trivialFunctor]


### PR DESCRIPTION
`ind₁`/`coind₁` are defined as the base change of finsupp/pi quotiented out by the trivial
relation.
This is because they are abbrevs of the general construction from mathlib.

Instead of redefining them as `G →₀ A`/`G → A` with the `G`-action on the domain, which would break
the defeq with the general construction, we provide `ind₁AsFinsupp`/`coind₁AsPi`, a version of
`ind₁`/`coind₁` that's actually defined as `G →₀ A`/`G → A`.

`ind₁AsFinsupp`/`coind₁AsPi` are not bundled as functors because they should only be used for
pointwise computations.

Co-authored-by: Arend Mellendijk
Co-authored-by: Michał Mrugała <kiolterino@gmail.com>