### PR TITLE
refactor: use `trivialFunctor` less, improve `ind₁AsFinsupp` API

### DIFF
--- a/ClassFieldTheory.lean
+++ b/ClassFieldTheory.lean
@@ -32,8 +32,10 @@ import ClassFieldTheory.Mathlib.Analysis.Normed.Unbundled.SpectralNorm
 import ClassFieldTheory.Mathlib.FieldTheory.Galois.NormalBasis
 import ClassFieldTheory.Mathlib.GroupTheory.OrderOfElement
 import ClassFieldTheory.Mathlib.GroupTheory.Torsion
+import ClassFieldTheory.Mathlib.LinearAlgebra.Finsupp.Defs
 import ClassFieldTheory.Mathlib.ModuleCatExact
 import ClassFieldTheory.Mathlib.RepresentationTheory.Homological.GroupCohomology.LowDegree
+import ClassFieldTheory.Mathlib.RepresentationTheory.Rep
 import ClassFieldTheory.Mathlib.RingTheory.Valuation.Basic
 import ClassFieldTheory.Mathlib.RingTheory.Valuation.ValuativeRel
 import ClassFieldTheory.Mathlib.Topology.Algebra.Module.FiniteDimension

--- a/ClassFieldTheory/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/ClassFieldTheory/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -1,0 +1,21 @@
+import Mathlib.LinearAlgebra.Finsupp.Defs
+
+/-!
+# TODO
+
+Rename `mapDomain.linearEquiv`!
+-/
+
+namespace Finsupp
+variable {α β M R : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+
+variable (M R) in
+@[simp] lemma coe_lmapDomain (f : α → β) : ⇑(lmapDomain M R f) = mapDomain f := rfl
+
+@[simp, norm_cast] lemma toLinearMap_mapDomainLinearEquiv (e : α ≃ β) :
+    mapDomain.linearEquiv M R e = lmapDomain M R e := rfl
+
+@[simp] lemma coe_mapDomainLinearEquiv (e : α ≃ β) :
+    ⇑(mapDomain.linearEquiv M R e) = equivMapDomain e := by ext; simp [mapDomain.linearEquiv]
+
+end Finsupp

--- a/ClassFieldTheory/Mathlib/RepresentationTheory/Rep.lean
+++ b/ClassFieldTheory/Mathlib/RepresentationTheory/Rep.lean
@@ -1,0 +1,18 @@
+import Mathlib.RepresentationTheory.Rep
+
+open CategoryTheory
+
+namespace Rep
+variable {R G : Type} [CommRing R] [Group G]
+
+-- TODO : add in mathlib, see GroupCohomology.IndCoind.TrivialCohomology
+--attribute [simps obj_ρ] trivialFunctor
+
+@[simps]
+def mkIso (M₁ M₂ : Rep R G) (f : M₁.V ≅ M₂.V)
+    (hf : ∀ g : G, ∀ m : M₁, f.hom (M₁.ρ g m) = M₂.ρ g (f.hom m) := by aesop) : M₁ ≅ M₂ where
+  hom.hom := f.hom
+  inv.hom := f.inv
+  inv.comm g := by rw [f.comp_inv_eq, Category.assoc, eq_comm, f.inv_comp_eq]; aesop
+
+end Rep


### PR DESCRIPTION
`(Rep.trivialFunctor R G).obj A` is just `Rep.trivial R G A`.