### PR TITLE
chore(blueprint): fix build errors and warnings

### DIFF
--- a/blueprint/src/_2_cohomology.tex
+++ b/blueprint/src/_2_cohomology.tex
@@ -916,7 +916,7 @@ This case is described again below.
 
 \section{Dimension-shifting}
 
-\subsection{Shifting $\up$}
+\subsection{Shifting \texorpdfstring{$\up$}{up}}
 
 \begin{definition} \label{def:coind₁'}
 	\lean{Representation.coind₁',
@@ -1050,7 +1050,7 @@ This case is described again below.
 \end{proof}
 
 
-\subsection{Shifting $\down$}
+\subsection{Shifting \texorpdfstring{$\down$}{down}}
 Let $G$ be a group and $M$ a representation of $G$ over a commutative ring $R$.
 
 \begin{definition} \label{def:ind'}
@@ -1611,7 +1611,7 @@ very precisely here:
 \end{proof}
 
 
-\begin{def} \label{def:local inv}
+\begin{definition} \label{def:local inv}
 	\lean{localInv}
 	\leanok
 
@@ -1622,7 +1622,7 @@ very precisely here:
 		\sigma & \mapsto \sum_{i=0}^{n-1} \sigma(\gen^i,\gen)
 	\end{align*}
 	is called the \emph{local invariant} of $G$.
-\end{lemma}
+\end{definition}
 
 
 \begin{lemma} \label{lem:local inv iso}

--- a/blueprint/src/_3_local.tex
+++ b/blueprint/src/_3_local.tex
@@ -265,7 +265,7 @@ $h(l/k,l^\times) = [l:k]$.
 
 
 
-\section{An upper bound for \texorpdfstring{$H^2(l/k,l^\times)$}{$H^2(l/k,l*)$}}
+\section{An upper bound for \texorpdfstring{$H^2(l/k,l^\times)$}{H2(l/k,l*)}}
 
 From now on $k$ and $l$ have characteristic zero.
 

--- a/blueprint/src/_4_global.tex
+++ b/blueprint/src/_4_global.tex
@@ -49,7 +49,7 @@ Furthmore, the inflation map for a tower of Galois extensions $l/m/k$ takes the 
 
 
 
-\section{Choice of $S$}
+\section{Choice of \texorpdfstring{$S$}{S}}
 
 Let $S$ be a finite set of places of $k$, containing all of the infinite primes and all
 of the primes which ramify in $l$.
@@ -88,7 +88,7 @@ whereas the cohomology groups of $\A_l^\times$ and $l^\times$ are infinite.
 
 
 
-\section{The Herbrand quotient of the $S$-ideles}
+\section{The Herbrand quotient of the \texorpdfstring{$S$}{S}-ideles}
 
 Let $v$ be a place of $k$ and $\hat v$ a place of $l$ above $v$.
 We'll write $D_{\hat v}$ the decomposition group at $\hat v$.
@@ -187,7 +187,7 @@ We'll write $D_{\hat v}$ the decomposition group at $\hat v$.
 
 
 
-\section{The Herbrand quotient of the $S$-units}
+\section{The Herbrand quotient of the \texorpdfstring{$S$}{S}-units}
 
 Define the \emph{logarithmic space} $V_S$ to be the following finite dimensional vector space
 over the real numbers:
@@ -422,7 +422,7 @@ The kernel of $\log_S$ is the finite group of roots of unity in $k$.
 
 
 
-\section{Some $L$-functions}
+\section{Some \texorpdfstring{$L$}{L}-functions}
 
 \begin{lemma} \label{lem:H0 idele class group finite}
 	$H^0_{\Tate}(l/k,\Cl_l)$ is finite.


### PR DESCRIPTION
Some wrong delimiters on a declaration I just added as well as a bunch of missing `\texorpdfstring`.