### PR TITLE
chore(blueprint): mark corestriction as done

### DIFF
--- a/blueprint/src/_2_cohomology.tex
+++ b/blueprint/src/_2_cohomology.tex
@@ -1364,8 +1364,10 @@ goes in the other direction, i.e. $\cor : H^\bullet (S,-)$ to $H^\bullet(G,-)$.
 We define this now, and point out some easy consequences of the definition.
 
 \begin{definition} \label{def:corestriction}
-	\lean{}
+	\lean{groupCohomology.cores₀}
 	\uses{cor:up iso}
+	\leanok
+
 	Let $S$ be a subgroup of finite index in $G$ and let $\{r_i\}$
 	be a set of representatives for the cosets $r_i S$.
 	For any representation $M$ of $G$ there is a linear map $N_{G/S} : M^S \to M^G$


### PR DESCRIPTION
Note to future Kevin: `\lean{}` makes the blueprint think that the corresponding declaration is ``. Please comment it out!