### PR TITLE
Don't `import Mathlib`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,11 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # TODO: Enforce
-      # - name: Don't 'import Mathlib', use precise imports
-      #   if: always()
-      #   run: |
-      #     ! (find ClassFieldTheory -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Mathlib$')
+      - name: Don't 'import Mathlib', use precise imports
+        if: always()
+        run: |
+          ! (find ClassFieldTheory -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Mathlib$')
 
       - name: Files in ClassFieldTheory.Mathlib can't import ClassFieldTheory files outside ClassFieldTheory.Mathlib
         run: |

--- a/ClassFieldTheory/GroupCohomology/03_inflation.lean
+++ b/ClassFieldTheory/GroupCohomology/03_inflation.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«02_restriction»
 
 /-

--- a/ClassFieldTheory/GroupCohomology/06_LeftRegular.lean
+++ b/ClassFieldTheory/GroupCohomology/06_LeftRegular.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«05_TrivialCohomology»
 
 section Group
@@ -39,13 +38,7 @@ lemma eq_sum_smul_of (v : leftRegular R G) : v = ∑ x ∈ v.support, (v x) • 
 lemma ρ_apply (g : G) : (leftRegular R G).ρ g = lmapDomain R R (g * ·) := rfl
 
 lemma ρ_apply₃_self_mul (g : G) (v : leftRegular R G) (x : G) :
-    ((leftRegular R G).ρ g v) (g * x) = v x := by
-  rw [ρ_apply, lmapDomain_apply]
-  have : Function.Injective (g * ·)
-  · intro x y hxy
-    dsimp at hxy
-    simpa using hxy
-  exact mapDomain_apply this v x
+    (leftRegular R G).ρ g v (g * x) = v x := mapDomain_apply (mul_right_injective _) v x
 
 lemma ρ_apply₃ (g : G) (v : leftRegular R G) (x : G) :
     ((leftRegular R G).ρ g v) x = v (g⁻¹ * x) := by
@@ -99,8 +92,7 @@ lemma ε_comp_ρ_apply (g : G) (v : (leftRegular R G).V) :
 
 @[simp]
 lemma ε_of (g : G) : ε R G (of g) = (1 : R) := by
-  have : of g = (leftRegular R G).ρ g (of 1)
-  · rw [ρ_apply_of, mul_one]
+  have : of g = (leftRegular R G).ρ g (of 1) := by rw [ρ_apply_of, mul_one]
   rw [this, ε_comp_ρ_apply, ε_of_one]
 
 instance : AddMonoidHomClass (Action.HomSubtype (ModuleCat R) G (leftRegular R G) (trivial R G R))

--- a/ClassFieldTheory/GroupCohomology/07_coind1_and_ind1.lean
+++ b/ClassFieldTheory/GroupCohomology/07_coind1_and_ind1.lean
@@ -1,9 +1,9 @@
 import ClassFieldTheory.GroupCohomology.«03_inflation»
-import ClassFieldTheory.GroupCohomology.«05_TrivialCohomology»
 import ClassFieldTheory.Mathlib.Algebra.Algebra.Equiv
-import Mathlib.FieldTheory.Galois.NormalBasis
 import ClassFieldTheory.Mathlib.LinearAlgebra.Finsupp.Defs
-import ClassFieldTheory.Mathlib.RepresentationTheory.Rep
+import Mathlib.Data.Finsupp.Notation
+import Mathlib.FieldTheory.Galois.NormalBasis
+import Mathlib.RepresentationTheory.FiniteIndex
 
 /-!
 Let `G` be a group. We define two functors:
@@ -287,28 +287,28 @@ between `ind₁' ρ` and `ind₁ R G V`.
       simp [ind₁'_invlmap_aux]
   right_inv f := by
     rw [LinearMap.toFun_eq_coe]
-    induction' f using Submodule.Quotient.induction_on with f
-    induction' f using TensorProduct.induction_on
-    · simp
-    · rename_i x y
-      simp only [ind₁'_invlmap, Submodule.quotEquivOfEqBot,
-        LinearEquiv.ofLinear_toLinearMap, LinearMap.coe_comp, Function.comp_apply]
-      change ρ.ind₁'_lmap ((TensorProduct.lift ρ.ind₁'_invlmap_aux)
-        (LinearMap.id (R := R) (x ⊗ₜ[R] y))) = Submodule.Quotient.mk (x ⊗ₜ[R] y)
-      simp only [LinearMap.id_coe, id_eq, TensorProduct.lift.tmul]
-      induction x using Finsupp.induction_linear
-      · simp
-      · rename_i f g h1 h2
-        rw [map_add, LinearMap.add_apply, map_add, h1, h2, TensorProduct.add_tmul]
-        rfl
-      · rename_i g r
-        simp [ind₁'_invlmap_aux, Coinvariants.mk]
-        rw [← map_smul, ← Submodule.mkQ_apply]
-        congr
-        rw [TensorProduct.smul_tmul', Finsupp.smul_single, smul_eq_mul, mul_one]
-    · rename_i f g h1 h2
+    induction f using Submodule.Quotient.induction_on with | H f
+    induction f using TensorProduct.induction_on with
+    | zero => simp
+    | add f g h1 h2 =>
       rw [← Submodule.mkQ_apply, map_add, map_add, map_add,
         Submodule.mkQ_apply, Submodule.mkQ_apply, h1, h2]
+    | tmul x y =>
+    simp only [ind₁'_invlmap, Submodule.quotEquivOfEqBot,
+      LinearEquiv.ofLinear_toLinearMap, LinearMap.coe_comp, Function.comp_apply]
+    change ρ.ind₁'_lmap (TensorProduct.lift ρ.ind₁'_invlmap_aux (LinearMap.id (R := R) (x ⊗ₜ[R] y)))
+      = Submodule.Quotient.mk (x ⊗ₜ[R] y)
+    simp only [LinearMap.id_coe, id_eq, TensorProduct.lift.tmul]
+    induction x using Finsupp.induction_linear with
+    | zero => simp
+    | add f g h1 h2 =>
+      rw [map_add, LinearMap.add_apply, map_add, h1, h2, TensorProduct.add_tmul]
+      rfl
+    | single g r =>
+      simp [ind₁'_invlmap_aux, Coinvariants.mk]
+      rw [← map_smul, ← Submodule.mkQ_apply]
+      congr
+      rw [TensorProduct.smul_tmul', Finsupp.smul_single, smul_eq_mul, mul_one]
 
 @[simp] lemma ind₁'_lequiv_comp_lsingle (x : G) :
     ρ.ind₁'_lequiv ∘ₗ lsingle x = Ind₁V.mk R G V x ∘ₗ ρ x := by ext; simp

--- a/ClassFieldTheory/GroupCohomology/10_inflationRestriction.lean
+++ b/ClassFieldTheory/GroupCohomology/10_inflationRestriction.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«03_inflation»
 import ClassFieldTheory.GroupCohomology.«08_DimensionShift»
 

--- a/ClassFieldTheory/GroupCohomology/11_TrivialityCriterion.lean
+++ b/ClassFieldTheory/GroupCohomology/11_TrivialityCriterion.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«04_TateCohomology_def»
 import ClassFieldTheory.GroupCohomology.«05_TrivialCohomology»
 import ClassFieldTheory.GroupCohomology.«08_DimensionShift»
@@ -6,6 +5,7 @@ import ClassFieldTheory.GroupCohomology.«10_inflationRestriction»
 import ClassFieldTheory.GroupCohomology.«09_CyclicGroup»
 import ClassFieldTheory.GroupCohomology.«15_corestriction»
 import ClassFieldTheory.Mathlib.Algebra.Group.Solvable
+import Mathlib.GroupTheory.Nilpotent
 
 /-
 Suppose `G` is a finite group, and there are positive integers `r` and `s`

--- a/ClassFieldTheory/GroupCohomology/12_augmentationModule.lean
+++ b/ClassFieldTheory/GroupCohomology/12_augmentationModule.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«05_TrivialCohomology»
 import ClassFieldTheory.GroupCohomology.«02_restriction»
 import ClassFieldTheory.GroupCohomology.«06_LeftRegular»

--- a/ClassFieldTheory/GroupCohomology/13_HerbrandQuotient.lean
+++ b/ClassFieldTheory/GroupCohomology/13_HerbrandQuotient.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«09_CyclicGroup»
 import ClassFieldTheory.GroupCohomology.«04_TateCohomology_def»
 

--- a/ClassFieldTheory/GroupCohomology/14_SplittingModule.lean
+++ b/ClassFieldTheory/GroupCohomology/14_SplittingModule.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«05_TrivialCohomology»
 import ClassFieldTheory.GroupCohomology.«11_TrivialityCriterion»
 import ClassFieldTheory.GroupCohomology.«12_augmentationModule»

--- a/ClassFieldTheory/GroupCohomology/15_corestriction.lean
+++ b/ClassFieldTheory/GroupCohomology/15_corestriction.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Aaron Liu
 -/
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«08_DimensionShift»
 
 /-

--- a/ClassFieldTheory/GroupCohomology/Examples/Examples.lean
+++ b/ClassFieldTheory/GroupCohomology/Examples/Examples.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.RepresentationTheory.Homological.GroupCohomology.LongExactSequence
+import Mathlib.RepresentationTheory.Homological.GroupHomology.LongExactSequence
 
 /-!
 

--- a/ClassFieldTheory/GroupCohomology/HerbrandInt.lean
+++ b/ClassFieldTheory/GroupCohomology/HerbrandInt.lean
@@ -1,12 +1,10 @@
-import Mathlib
 import ClassFieldTheory.GroupCohomology.«13_HerbrandQuotient»
+import Mathlib.Data.ZMod.QuotientRing
 
 variable {G : Type} [Group G] [Fintype G] [IsCyclic G]
 
 open groupCohomology
   Representation
-
-attribute [-instance] NormedAddCommGroup.toENormedAddCommMonoid
 
 omit [IsCyclic G] in
 @[simp] lemma norm_trivial_int_eq_card : (trivial ℤ G ℤ).norm = Nat.card G := by

--- a/ClassFieldTheory/GroupCohomology/IndCoind/TrivialCohomology.lean
+++ b/ClassFieldTheory/GroupCohomology/IndCoind/TrivialCohomology.lean
@@ -9,6 +9,8 @@ import ClassFieldTheory.GroupCohomology.«07_coind1_and_ind1»
 import ClassFieldTheory.Mathlib.Algebra.Module.Submodule.Range
 import ClassFieldTheory.Mathlib.LinearAlgebra.Finsupp.Defs
 import ClassFieldTheory.Mathlib.RepresentationTheory.Rep
+import Mathlib.RepresentationTheory.Homological.GroupCohomology.Shapiro
+import Mathlib.RepresentationTheory.Homological.GroupHomology.Shapiro
 
 /-!
 # (Co)induced modules have trivial (co)homology
@@ -212,8 +214,8 @@ instance coind₁_quotientToInvariants_trivialCohomology (A : ModuleCat R) {Q : 
 instance coind₁'_quotientToInvariants_trivialCohomology {Q : Type} [Group Q] {φ : G →* Q}
     (surj : Function.Surjective φ) : ((coind₁'.obj M) ↑ surj).TrivialCohomology := by
   have iso := (quotientToInvariantsFunctor' surj).mapIso (coind₁'_obj_iso_coind₁ M)
-  have _ : ((quotientToInvariantsFunctor' surj).obj ((coind₁ G).obj M.V)).TrivialCohomology
-  · exact coind₁_quotientToInvariants_trivialCohomology M.V surj
+  have : ((quotientToInvariantsFunctor' surj).obj ((coind₁ G).obj M.V)).TrivialCohomology :=
+    coind₁_quotientToInvariants_trivialCohomology M.V surj
   exact .of_iso iso
 
 end Rep


### PR DESCRIPTION
Importing all of mathlib makes loading files *significantly* slower (about two minutes on my machine, vs 10-15s otherwise), and building the docs too. It furthermore imports the legacy `have` syntax, which is not allowed in mathlib, and parasite typeclasses that in one instance we had to turn off. This PR removes all occurrences of `import Mathlib` from the repo and turns on the linter against them. The linter only runs in CI, so one can still use `import Mathlib` for development.