### PR TITLE
fix: fix decls

### DIFF
--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -113,4 +113,3 @@ Rep.dimensionShift.up_trivialCohomology
 Rep.dimensionShift.down_trivialCohomology
 Rep.tateCohomology_of_trivialCohomology
 Rep.trivialHomology_of_trivialCohomology
-NumberField.Units.dirichletUnitTheorem.unitLattice_span_eq_top

--- a/blueprint/src/_4_global.tex
+++ b/blueprint/src/_4_global.tex
@@ -251,14 +251,14 @@ where the $w$-component of $\log_S(x)$ is $\log |x|_w$.
 The kernel of $\log_S$ is the finite group of roots of unity in $k$.
 
 \begin{theorem} \label{thm:Dirichlet unit theorem}
-	\lean{NumberField.Units.dirichletUnitTheorem.unitLattice_span_eq_top}
-	\mathlibok
+	%\lean{NumberField.Units.dirichletUnitTheorem.unitLattice_span_eq_top}
+	%\mathlibok
 	$\log_S(\cO_S^\times)$ has zero intersection with $\Span (1,1,\ldots,1)$.
 	The direct sum of these subrepresentations is a lattice in $V_S$.
 \end{theorem}
 
 \begin{proof}
-	\mathlibok
+	%\mathlibok
 	An equivalent statement is already in Mathlib as
 	\texttt{NumberField.Units.dirichletUnitTheorem.unitLattice\_span\_eq\_top}.
 \end{proof}


### PR DESCRIPTION
We don't import Mathlib any more so we don't import Dirichlet's units theorem, which we use in the global argument. Right now there are no plans to start working on the global argument so instead I just comment out the Lean declaration in the LaTeX.