### PR TITLE
chore: fix checkdecls

### DIFF
--- a/ClassFieldTheory/Cohomology/FiniteCyclic/HerbrandQuotient/Trivial.lean
+++ b/ClassFieldTheory/Cohomology/FiniteCyclic/HerbrandQuotient/Trivial.lean
@@ -50,7 +50,8 @@ instance : Subsingleton (trivial ℤ G ℤ).herbrandH1 :=
   Quot.Subsingleton
 
 variable (G) in
-theorem herbrandQuotient_trivial_int_eq_card : herbrandQuotient (trivial ℤ G ℤ) = Nat.card G := by
+theorem Representation.herbrandQuotient_trivial_int_eq_card :
+    herbrandQuotient (trivial ℤ G ℤ) = Nat.card G := by
   unfold herbrandQuotient
   rw [card_herbrandH0_trivial_int, Nat.card_of_subsingleton (0 : (trivial ℤ G ℤ).herbrandH1)]
   simp only [Nat.cast_one, div_one]
@@ -58,4 +59,5 @@ theorem herbrandQuotient_trivial_int_eq_card : herbrandQuotient (trivial ℤ G �
 variable (G) in
 theorem Rep.herbrandQuotient_trivial_int_eq_card :
     Rep.herbrandQuotient (trivial ℤ G ℤ) = Nat.card G := by
-  classical rw [trivial, herbrandQuotient_of, _root_.herbrandQuotient_trivial_int_eq_card]
+  classical rw [trivial, herbrandQuotient_of,
+    Representation.herbrandQuotient_trivial_int_eq_card]

--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -107,6 +107,12 @@ carryCocycle
 localInv
 localInvIso
 localInv_symm_apply
+Representation.herbrandQuotient
+Rep.herbrandQuotient
+Representation.herbrandQuotient_trivial_int_eq_card
+Rep.herbrandQuotient_trivial_int_eq_card
+Representation.herbrandQuotient_of_finite
+Rep.herbrandQuotient_of_finite
 groupCohomology.trivialCohomology_of_even_of_odd_of_solvable
 groupCohomology.trivialCohomology_of_even_of_odd
 Rep.dimensionShift.up_trivialCohomology


### PR DESCRIPTION
They were broken by recent changes but we didn't notice because CI is failing for unrelated reasons beyond our control and it's the weekend so they're not being fixed.