### PR TITLE
hack to fix CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,6 +61,6 @@ jobs:
       - if: github.ref == 'refs/heads/main'
         name: Build project documentation
         id: build-docgen
-        uses: leanprover-community/docgen-action@main
+        uses: leanprover-community/docgen-action@1417dc7f90338c875da5e5870c03a287d8348896 # docgen-action#11
         with:
           blueprint: true


### PR DESCRIPTION
Revert this when https://github.com/leanprover-community/docgen-action/pull/11 is merged but right now our repo is active and we managed to break CI in a second way without noticing so I think I'll merge this now.