### PR TITLE
disable docgen

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,4 +67,4 @@ jobs:
         id: build-docgen
         uses: leanprover-community/docgen-action@main
         with:
-          blueprint: true
+          blueprint: false


### PR DESCRIPTION
Currently the main branch is failing because of docgen, I think it's fine to disable it for now since the main contributors to this project know what they are doing